### PR TITLE
docs: add AGENTS.md with conventional commits and PR guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,16 @@ Common types:
 - `chore` — other changes that don't modify src or test files
 
 Use `!` after the type/scope or a `BREAKING CHANGE:` footer to mark breaking changes.
+
+## Pull Requests
+
+When work on a branch is complete, push the branch and open a pull request automatically using the [`gh` CLI](https://cli.github.com/) rather than waiting for the user to do it manually.
+
+Typical flow:
+
+```
+git push -u origin <branch>
+gh pr create --fill
+```
+
+Use `--fill` to seed the title and body from the commit messages, or pass `--title` / `--body` explicitly when more context is needed. Target the default branch unless the ticket says otherwise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# Agent Guidelines
+
+## Commit Messages
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/).
+
+Format commit messages as:
+
+```
+<type>(<optional scope>): <description>
+```
+
+Common types:
+
+- `feat` — a new feature
+- `fix` — a bug fix
+- `docs` — documentation only changes
+- `style` — formatting, missing semicolons, etc. (no code change)
+- `refactor` — code change that neither fixes a bug nor adds a feature
+- `perf` — performance improvement
+- `test` — adding or updating tests
+- `build` — build system or external dependency changes
+- `ci` — CI configuration changes
+- `chore` — other changes that don't modify src or test files
+
+Use `!` after the type/scope or a `BREAKING CHANGE:` footer to mark breaking changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md` outlining the Conventional Commits format and the common types/scopes used in this repo
- Symlinks `CLAUDE.md` → `AGENTS.md` so Claude Code picks up the same guidance
- Steers agents to push and open PRs automatically with the `gh` CLI when work is complete

## Test plan
- [ ] Confirm `CLAUDE.md` resolves to `AGENTS.md` contents
- [ ] Confirm rendered Markdown looks correct on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)