### PR TITLE
Add publishable kanco agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,28 @@ Tools exposed:
 | `link_pr`        | Link a PR URL; state drives column |
 | `unlink_pr`      | Remove a PR link |
 
+## Agent skill
+
+A publishable Claude Agent skill in [`skills/kanco`](skills/kanco) teaches
+LLMs the kanco workflow: create a Todo ticket on task accept, move through
+Planning → In Progress, link the PR when opened, and let kanco auto-drive
+In Review / Done from GitHub PR state. Use subtasks for parallel streams of
+work.
+
+Install with the [`skills`](https://www.npmjs.com/package/skills) CLI — no
+clone needed:
+
+```sh
+npx skills add jshthornton/kanco --skill kanco
+```
+
+Or just ask your agent: *"Install the kanco skill from
+github.com/jshthornton/kanco."* Manual fallback:
+
+```sh
+mkdir -p ~/.claude/skills && cp -r skills/kanco ~/.claude/skills/
+```
+
 ## Why no Docker?
 
 kanco spawns agent shells on the host so they can run your real toolchain

--- a/skills/kanco/README.md
+++ b/skills/kanco/README.md
@@ -1,0 +1,46 @@
+# kanco skill
+
+A Claude Agent skill that teaches an LLM how to drive its own work across a
+[kanco](../../README.md) board via the kanco MCP server.
+
+The skill instructs the agent to:
+
+- Create a Todo ticket as soon as it accepts a task
+- Move the ticket to Planning while it scopes and designs
+- Move to In Progress when it starts writing code
+- Split parallel streams of work into subtasks
+- Link the PR as soon as it is opened, then let kanco auto-move the ticket
+  to In Review (open PR) and Done (merged PR) based on GitHub state
+
+## Install
+
+### With the `skills` CLI (recommended)
+
+```sh
+npx skills add jshthornton/kanco --skill kanco
+```
+
+Works with Claude Code, Cursor, Windsurf, and other agents that follow the
+open Agent Skills layout.
+
+### Or ask your agent
+
+> "Install the kanco skill from github.com/jshthornton/kanco."
+
+### Manual
+
+```sh
+mkdir -p ~/.claude/skills
+cp -r skills/kanco ~/.claude/skills/
+```
+
+Then add the kanco MCP endpoint:
+
+```sh
+claude mcp add kanco http://localhost:8787/mcp --transport http
+```
+
+### Other agents
+
+The skill is a single `SKILL.md` file with YAML frontmatter — copy it into
+whatever skill / system-prompt mechanism your agent supports.

--- a/skills/kanco/SKILL.md
+++ b/skills/kanco/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: kanco
+description: Use the kanco MCP to track work on a kanban board. Create a Todo ticket as soon as you accept a task, move it to Planning while you scope, In Progress when you start coding, link the PR when you open one, and let kanco auto-move it to In Review and Done based on GitHub PR state. Split parallel streams of work into subtasks.
+---
+
+# kanco — agent workflow
+
+kanco is a local-first kanban board that exposes an MCP server. As an agent, you
+drive your own card across the board so the human can see what you are doing.
+Column transitions after the PR is linked are **automatic** — do not move the
+ticket yourself once a PR exists.
+
+## The columns
+
+| Column        | Who moves it                                          |
+| ------------- | ----------------------------------------------------- |
+| Todo          | You, when the task is accepted                        |
+| Planning      | You, while scoping / designing                        |
+| In Progress   | You, when you start writing code                      |
+| In Review     | **kanco**, when the linked PR is open (non-draft)     |
+| Done          | **kanco**, when the linked PR is merged               |
+
+A manual move suppresses PR-driven auto-transitions for 1 hour, so only move
+manually when you genuinely need to override.
+
+## Tools
+
+All tools are exposed by the `kanco` MCP server (default
+`http://localhost:8787/mcp`).
+
+| Tool             | Use it for                                                                   |
+| ---------------- | ---------------------------------------------------------------------------- |
+| `list_spaces`    | Find the space (board) to work in                                            |
+| `create_space`   | Create a new board if none fits                                              |
+| `list_tickets`   | Find an existing ticket; optionally filter by `column`                       |
+| `get_ticket`     | Read a ticket with its PR links and subtasks                                 |
+| `create_ticket`  | Create a Todo ticket (or pass `column` / `parent_ticket_id`)                 |
+| `create_subtask` | Split a separate stream of work off the parent ticket                        |
+| `update_ticket`  | Refine the title or body as you learn more                                   |
+| `move_ticket`    | Move by column **name** — counts as a manual override                        |
+| `link_pr`        | Attach a GitHub PR; kanco then drives the column from PR state               |
+| `unlink_pr`      | Detach a PR link                                                             |
+
+## Workflow — follow this every task
+
+### 1. Accept the task → create a Todo ticket immediately
+
+The moment you understand what is being asked, call `create_ticket` with a
+clear title and a body that captures the ask. Do this **before** you start
+exploring or designing. The default column is Todo, which is what you want.
+
+If you cannot find a fitting space, call `list_spaces`; create one with
+`create_space` only if there is genuinely no home for the work.
+
+### 2. Move to Planning while you scope
+
+When you start exploring the codebase, drafting a plan, or asking
+clarifying questions, call `move_ticket` with `column: "Planning"`. Update
+the ticket body via `update_ticket` as your understanding firms up — the
+human will read this to follow along.
+
+### 3. Move to In Progress when you start coding
+
+The first time you edit code (not just read it), call `move_ticket` with
+`column: "In Progress"`.
+
+### 4. Use subtasks for parallel streams of work
+
+If the work naturally splits into independent pieces (e.g. backend +
+frontend, or three unrelated refactors), call `create_subtask` for each
+piece. Subtasks live under the parent on the board and have their own
+columns and PR links. Use them when:
+
+- The pieces ship as separate PRs
+- The pieces could be picked up by different agents in parallel
+- The parent is too coarse to track state meaningfully
+
+Do **not** create subtasks for trivially small steps — keep them at the
+"separate stream" granularity.
+
+### 5. Link the PR as soon as you open one
+
+Right after `gh pr create` (or equivalent), call `link_pr` with the ticket
+id and the PR URL. From this point on, **kanco owns the column**:
+
+- Draft PR → ticket stays in **In Progress**
+- Open PR (ready for review) → ticket auto-moves to **In Review**
+- PR merged → ticket auto-moves to **Done**
+- PR closed without merge → ticket auto-moves back to **Todo**
+
+Do not call `move_ticket` after linking unless you explicitly need to
+override — manual moves suppress automatic transitions for 1 hour.
+
+If a task spawned subtasks, link each subtask's PR to that subtask, not to
+the parent.
+
+## Quick reference
+
+```text
+accept task        → create_ticket (Todo)
+start scoping      → move_ticket   (Planning)
+start coding       → move_ticket   (In Progress)
+parallel work      → create_subtask
+opened a PR        → link_pr       (kanco drives the rest)
+PR ready for review→ (auto: In Review)
+PR merged          → (auto: Done)
+PR closed unmerged → (auto: Todo)
+```
+
+## Notes
+
+- Every MCP mutation is tagged `mcp:<client>` in the audit log and shown on
+  the card, so the human sees exactly what you did.
+- `move_ticket` and `create_ticket` accept the column **name**
+  (case-insensitive), not an id.
+- If `link_pr` fails with "invalid PR URL", pass the full
+  `https://github.com/owner/repo/pull/N` URL.


### PR DESCRIPTION
## Summary
- Adds `skills/kanco/SKILL.md`, a publishable Claude Agent skill that teaches LLMs the kanco MCP workflow
- Skill prescribes: create Todo on task accept → Planning while scoping → In Progress when coding → `link_pr` so kanco auto-drives In Review / Done from GitHub state
- Documents subtasks for parallel streams of work and warns that manual moves suppress auto-transitions for 1h
- Adds short install README for the skill and links it from the top-level README

## Test plan
- [ ] Copy `skills/kanco` into `~/.claude/skills/` and confirm Claude Code picks it up
- [ ] Verify the skill content matches the actual MCP tool surface in `apps/server/src/mcp/server.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Added comprehensive documentation for the kanco skill, a new agent-driven kanban board automation system for managing ticket workflows.
- Includes installation and setup instructions with detailed operational guidelines for ticket creation, status progression through planning and in-progress stages, subtask management for parallel work, and GitHub PR linking for automatic status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->